### PR TITLE
Retornar mensagem de erro e código de status ao construir mensagens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Vindi Ruby
 
+[![Build Status](https://semaphoreci.com/api/v1/projects/48986e75-f1a3-4ca3-ae41-2d6cf64ac507/1512354/badge.svg)](https://semaphoreci.com/vindi/vindi-ruby)
+
+## Descrição
+
 Ruby toolkit para a [API de Recorrência][link-introducao-api] da [Vindi][link-vindi].
 
-[![Build Status](https://semaphoreci.com/api/v1/projects/48986e75-f1a3-4ca3-ae41-2d6cf64ac507/1512354/badge.svg)](https://semaphoreci.com/vindi/vindi-ruby)
+## Requisitos
+
+* Ruby >=2.3;
+* Certificado digital HTTPS assinado por uma entidade certificadora;
+* Conta ativa na [Vindi](https://www.vindi.com.br).
 
 ## Instalação
 
@@ -10,11 +18,11 @@ Ruby toolkit para a [API de Recorrência][link-introducao-api] da [Vindi][link-v
 gem 'vindi'
 ```
 
-And then execute:
+Então execute:
 
     $ bundle
 
-Or install it yourself as:
+Ou instale você mesmo:
 
     $ gem install vindi
 
@@ -23,10 +31,10 @@ Os métodos da API estão disponíveis atraves dos métodos da instancia de um c
 
 ```ruby
   client = Vindi::Client.new(key: 'VINDI_KEY')
-``` 
+```
 
 ### Consumindo recursos
-Os recursos são fornecidos através do objeto de retono e os campos retornados podem ser acessados pela notação de attributos de um Hash 
+Os recursos são fornecidos através do objeto de retorno e os campos retornados podem ser acessados pela notação de attributos de um Hash
 
 ```ruby
   # Listando planos de um lojista
@@ -43,7 +51,7 @@ Os recursos são fornecidos através do objeto de retono e os campos retornados 
 
   # Criando um plano
   client.create_plan({name: 'My new plan', interval: 'months', interval_count: 1,  billing_trigger_type: 'beginning_of_period'})
-``` 
+```
 
 ### Acessando respostas HTTP
 
@@ -51,7 +59,7 @@ Os recursos são fornecidos através do objeto de retono e os campos retornados 
   client.list_plans
   response  = client.last_response
   status = response.status
-``` 
+```
 
 ## Dúvidas
 Caso necessite de informações sobre a plataforma ou API, por favor acesse o [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br).

--- a/lib/vindi/error.rb
+++ b/lib/vindi/error.rb
@@ -1,6 +1,7 @@
 module Vindi
   # Custom error class for rescuing from all Vindi errors
   class Error < StandardError
+    attr_accessor :status_code
 
     # Raised when Vindi returns a 4xx HTTP status code
     ClientError = Class.new(self)
@@ -68,9 +69,11 @@ module Vindi
     end
 
     def build_error_message(response)
-      return if response.nil?
+      return if response.nil? or response.body.nil?
 
-      message  = "#{response[:method].to_s.upcase} "
+      self.status_code = response.status
+
+      message = response.body
       message
     end
   end

--- a/lib/vindi/error.rb
+++ b/lib/vindi/error.rb
@@ -69,12 +69,11 @@ module Vindi
     end
 
     def build_error_message(response)
-      return if response.nil? or response.body.nil?
+      return unless response&.body
 
       self.status_code = response.status
 
-      message = response.body
-      message
+      response.body
     end
   end
 end

--- a/spec/vindi/client_spec.rb
+++ b/spec/vindi/client_spec.rb
@@ -60,11 +60,16 @@ RSpec.describe Vindi::Client do
     end
 
     describe 'errors' do
-      it 'retuns not found error' do
+      it 'raises a Vindi::Error::NotFound exception' do
+        VCR.use_cassette("raise_404_error") do
+          expect{ client.get 'hello' }.to raise_error Vindi::Error::NotFound
+        end
+      end
+
+      it 'returns an error with a 404 status code' do
         VCR.use_cassette("raise_404_error") do
           begin
             client.get 'hello'
-            expect(client.last_response.status).to eq 404
           rescue Vindi::Error::NotFound => error
             expect(error.status_code).to eq 404
           end

--- a/spec/vindi/client_spec.rb
+++ b/spec/vindi/client_spec.rb
@@ -62,8 +62,11 @@ RSpec.describe Vindi::Client do
     describe 'errors' do
       it 'retuns not found error' do
         VCR.use_cassette("raise_404_error") do
-          expect{ client.get 'hello' }
-            .to raise_error Vindi::Error::NotFound
+          begin
+            client.get 'hello'
+          rescue Vindi::Error::NotFound => error
+            expect(error.status_code).to eq 404
+          end
         end
       end
     end

--- a/spec/vindi/client_spec.rb
+++ b/spec/vindi/client_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Vindi::Client do
         VCR.use_cassette("raise_404_error") do
           begin
             client.get 'hello'
+            expect(client.last_response.status).to eq 404
           rescue Vindi::Error::NotFound => error
             expect(error.status_code).to eq 404
           end


### PR DESCRIPTION
Fornece o código de erro (.status_code) e o corpo da resposta como parâmetro da exceção (ao invés do protocolo utilizado na requisição). Torna transparente a resposta vinda do servidor em todos os casos de erro.