### PR TITLE
Permite atualizações da gem faraday

### DIFF
--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency 'faraday', '~> 0.13'
+  spec.add_dependency 'faraday', ['>= 0.13', '< 1.0']
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Não há necessidade de obrigar o uso da versão `0.13`. Gems como [oauth2](https://github.com/oauth-xx/oauth2/blob/master/oauth2.gemspec#L8) e [sentry-raven](https://github.com/getsentry/raven-ruby/blob/master/sentry-raven.gemspec#L20) deixam a versão da depedência `faraday` menos restrita. 