### PR TITLE
Adicionada classe de erro que estava faltando

### DIFF
--- a/lib/vindi/error.rb
+++ b/lib/vindi/error.rb
@@ -30,6 +30,9 @@ module Vindi
     # Raised when Vindi returns a 5xx HTTP status code
     ServerError = Class.new(self)
 
+    # Raised when Vindi returns the HTTP status code 500
+    InternalServerError = Class.new(ServerError)
+
     # Raised when Vindi returns the HTTP status code 502
     BadGateway = Class.new(ServerError)
 


### PR DESCRIPTION
Issue: #7 
### Motivação
A classe ``InternalServerError`` é referenciada porém nunca foi criada.
### Solução proposta
Instanciar a classe  ``InternalServerError`` para evitar erros desnecessários