### PR TITLE
Adicionado método para listar itens associados a uma assinatura.

### DIFF
--- a/lib/vindi/rest/subscription.rb
+++ b/lib/vindi/rest/subscription.rb
@@ -86,7 +86,7 @@ module Vindi
       # @params subscription_id
       # @see https://vindi.github.io/api-docs/dist/#!/subscriptions/GET_version_subscriptions_id_product_items_format
       # @example List subscription product items #2
-      #   client.list_subscription_product_items
+      #   client.list_subscription_product_items(2)
       def list_subscription_product_items(subscription_id, options = {})
         get("subscriptions/#{subscription_id}/product_items", options)[:product_items]
       end

--- a/lib/vindi/rest/subscription.rb
+++ b/lib/vindi/rest/subscription.rb
@@ -80,6 +80,16 @@ module Vindi
       def delete_subscription(subscription_id, options = {})
         delete("subscriptions/#{subscription_id}", options)[:subscription]
       end
+
+      # List product items for a subscription
+      #
+      # @params subscription_id
+      # @see https://vindi.github.io/api-docs/dist/#!/subscriptions/GET_version_subscriptions_id_product_items_format
+      # @example List subscription product items #2
+      #   client.list_subscription_product_items
+      def list_subscription_product_items(subscription_id, options = {})
+        get("subscriptions/#{subscription_id}/product_items", options)[:product_items]
+      end
     end
   end
 end

--- a/lib/vindi/version.rb
+++ b/lib/vindi/version.rb
@@ -1,3 +1,3 @@
 module Vindi
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/cassettes/vindi/rest/subscriptions/list_subscription_product_items.yml
+++ b/spec/cassettes/vindi/rest/subscriptions/list_subscription_product_items.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-app.vindi.com.br/api/v1/subscriptions/91327/product_items
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Vindi-Ruby/0.0.4
+      Authorization:
+      - Basic bEFzc2xFRGhRZkF3SnhMaGdKUnhkbkdmR0FYSVFfYjAtRlJ6RXZJMTk4Zzo=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2019 20:15:04 GMT
+      Etag:
+      - W/"b4cd04e22b42280aff7dfaa6fa46d641"
+      Per-Page:
+      - '25'
+      Rate-Limit-Limit:
+      - '120'
+      Rate-Limit-Remaining:
+      - '119'
+      Rate-Limit-Reset:
+      - '1556309764'
+      Server:
+      - nginx
+      Total:
+      - '1'
+      Vary:
+      - Origin
+      X-Request-Id:
+      - 7e6bf132-f88e-4c1f-bb07-9633ca342856
+      X-Runtime:
+      - '0.050027'
+      Content-Length:
+      - '433'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJwcm9kdWN0X2l0ZW1zIjpbeyJpZCI6MTI2ODEyLCJzdGF0dXMiOiJhY3RpdmUiLCJ1c2VzIjoxLCJjeWNsZXMiOm51bGwsInF1YW50aXR5IjoxLCJjcmVhdGVkX2F0IjoiMjAxOS0wNC0xOFQxMTozMDoxNC4wMDAtMDM6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxOS0wNC0xOFQxMTozMDoxNC4wMDAtMDM6MDAiLCJwcm9kdWN0Ijp7ImlkIjoxODc0MCwibmFtZSI6IlBsYW5vIELDoXNpY28iLCJjb2RlIjoiYmFzaWMifSwicHJpY2luZ19zY2hlbWEiOnsiaWQiOjkwOTk0LCJzaG9ydF9mb3JtYXQiOiJSJCAxOTcsMDAiLCJwcmljZSI6IjE5Ny4wIiwibWluaW11bV9wcmljZSI6bnVsbCwic2NoZW1hX3R5cGUiOiJmbGF0IiwicHJpY2luZ19yYW5nZXMiOltdLCJjcmVhdGVkX2F0IjoiMjAxOS0wNC0xN1QxMzozOToyOS4wMDAtMDM6MDAifSwiZGlzY291bnRzIjpbXX1dfQ==
+    http_version: 
+  recorded_at: Fri, 26 Apr 2019 20:15:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vindi/rest/subscription_spec.rb
+++ b/spec/vindi/rest/subscription_spec.rb
@@ -77,4 +77,14 @@ RSpec.describe Vindi::Client::Subscription do
       end
     end
   end
+
+  describe 'list_subscription_product_items' do
+    it 'returns the associated product items of subscription' do
+      VCR.use_cassette("rest/subscriptions/list_subscription_product_items") do
+        product_items = client.list_subscription_product_items(91327)
+        assert_requested :get, vindi_url("subscriptions/91327/product_items")
+        expect(product_items).to be_kind_of(Array)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Motivação
A rota de API de listagem de itens associados a uma assinatura não está disponível.

## Solução Proposta
O método `list_subscription_product_items` foi adicionado.

## Pendência
Não consegui gerar a fixture de requisição porque não tenho acesso ao ambiente de staging.
