### PR TITLE
Adicionado método para listar os registros de utilização associados ao período

### DIFF
--- a/lib/vindi/rest/period.rb
+++ b/lib/vindi/rest/period.rb
@@ -47,6 +47,18 @@ module Vindi
       def update_period(period_id, options = {})
         put("periods/#{period_id}", options)[:period]
       end
+
+      # List period usages
+      #
+      # @params period_id [Integer] ID of the period
+      # @option options [Integer] :page (1) Page number.
+      # @return [Array<Hash>] A list of usages for a period.
+      # @see https://vindi.github.io/api-docs/dist/#/periods/getV1PeriodsIdUsages
+      # @example List period usages
+      #   client.list_period_usages(2)
+      def list_period_usages(period_id, options = {})
+        get("periods/#{period_id}/usages", options)[:usages]
+      end
     end
   end
 end

--- a/spec/cassettes/vindi/rest/periods/list_period_usages.yml
+++ b/spec/cassettes/vindi/rest/periods/list_period_usages.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-app.vindi.com.br/api/v1/periods/382/usages
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Vindi-Ruby/0.0.6
+      Authorization:
+      - Basic eER3M2VsUHdkZGx6cWdGekpxWlhraXktalpselZ2WTdMMWFWZGNEYk1IZzo=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 13 Oct 2020 20:51:35 GMT
+      Etag:
+      - W/"17c4110884e91e08af771af131522a10"
+      Per-Page:
+      - '25'
+      Rate-Limit-Limit:
+      - '120'
+      Rate-Limit-Remaining:
+      - '119'
+      Rate-Limit-Reset:
+      - '1602622355'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Total:
+      - '1'
+      Vary:
+      - Origin
+      X-Request-Id:
+      - 544a5bfc-3f52-40c4-95f7-8557d711e818
+      X-Runtime:
+      - '0.045795'
+      Content-Length:
+      - '269'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"usages":[{"id":653,"quantity":3,"description":null,"created_at":"2017-09-08T11:36:23.358-03:00","metadata":{},"product_item":{"id":141,"product":{"id":48,"name":"t-shirt
+        one","code":null}},"bill":null}]}'
+  recorded_at: Tue, 13 Oct 2020 20:51:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vindi/rest/period_spec.rb
+++ b/spec/vindi/rest/period_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe Vindi::Client::Period do
       end
     end
   end
+
+  describe 'list_period_usages' do
+    it 'returns a collection of usages for given period' do
+      VCR.use_cassette("rest/periods/list_period_usages") do
+        usages_response = client.list_period_usages(382)
+        assert_requested :get, vindi_url("periods/382/usages")
+        expect(usages_response).to be_kind_of(Array)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Método implementado: https://vindi.github.io/api-docs/dist/#/periods/getV1PeriodsIdUsages