### PR TITLE
Upgrade para nova versão da biblioteca Faraday.

### DIFF
--- a/lib/vindi/response/raise_error.rb
+++ b/lib/vindi/response/raise_error.rb
@@ -7,10 +7,8 @@ module Vindi
     # This class raises exceptions based HTTP status codes retuned by the API
     class RaiseError < Faraday::Response::Middleware
 
-      private
-
       def on_complete(response)
-       error = Vindi::Error.from_response(response)
+        error = Vindi::Error.from_response(response)
         raise error if error
       end
     end

--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency 'faraday', '~> 0.13'
+  spec.add_dependency 'faraday', '~> 1'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
A versão `1.0.1` do `faraday` foi lançada em março de 2020 e várias libs da comunidade já foram atualizadas para versão mais recente do `faraday`. Acho que passou da hora de atualizarmos também. :)