### PR TITLE
Atualiza versão mínima do rake para 12.3.3

### DIFF
--- a/lib/vindi/version.rb
+++ b/lib/vindi/version.rb
@@ -1,3 +1,3 @@
 module Vindi
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end

--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 1'
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
## O que mudou
Foi atualizada a versão mínima necessária da dependência `rake` para a versão `12.3.3` por correções de vulnerabilidades de segurança.

## Motivação
resolve: #33 
Há uma vulnerabilidade de injeção de comando do no gem Ruby `rake` em versões anteriores a `12.3.3` na classe `Rake::FileList` ao fornecer um nome de arquivo que começe com o caractere pipe `|`.

## Solução proposta
Atualizar a versão mínima para a versão sem a vulnerabilidade.
