### PR TITLE
Implementação de compatibilidade com Faraday 2

### DIFF
--- a/lib/vindi/connection.rb
+++ b/lib/vindi/connection.rb
@@ -1,5 +1,9 @@
 require 'faraday'
 require 'json'
+begin
+  require 'faraday/multipart'
+rescue LoadError
+end
 
 module Vindi
   module Connection
@@ -11,7 +15,7 @@ module Vindi
       @http_client = Faraday.new(api_endpoint, connection_options) do |http|
         http.request(:multipart)
         http.request(:url_encoded)
-        http.request(:basic_auth, @key, '')
+        http.set_basic_auth(@key, '')
         http.builder.use @middleware
         http.adapter(Faraday.default_adapter)
       end

--- a/lib/vindi/response/raise_error.rb
+++ b/lib/vindi/response/raise_error.rb
@@ -5,7 +5,7 @@ module Vindi
   module Response
 
     # This class raises exceptions based HTTP status codes retuned by the API
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
 
       def on_complete(response)
         error = Vindi::Error.from_response(response)

--- a/lib/vindi/version.rb
+++ b/lib/vindi/version.rb
@@ -1,3 +1,3 @@
 module Vindi
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end

--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency 'faraday', '~> 1'
+  spec.add_dependency "faraday", "< 3"
+  spec.add_development_dependency "faraday-multipart"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
### O que mudou?
Foi ajustada a compatibilidade com Faraday 2

#### Pontos importantes sobre compatibilidade com `faraday` sem major upgrade no versionamento da `vindi`:

- O método `set_basic_auth` está disponível tanto na `v1` quanto na `v2`. Easy win aqui.
- `Faraday::Response::Middleware` não tinha nenhuma utilidade de herança. Easy win também.  
- Cabe ao desenvolvedor adicionar a biblioteca `faraday-multipart` se estiver rodando o Faraday 2. Afinal, este é o pattern agora que praticamente tudo foi extraído em gems.