### PR TITLE
Adiciona dependência da gem `faraday-multipart`

### DIFF
--- a/lib/vindi/version.rb
+++ b/lib/vindi/version.rb
@@ -1,3 +1,3 @@
 module Vindi
-  VERSION = '0.0.12'
+  VERSION = '0.0.13'
 end

--- a/vindi.gemspec
+++ b/vindi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency "faraday", "< 3"
-  spec.add_development_dependency "faraday-multipart"
+  spec.add_dependency "faraday-multipart"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
## Motivação
Está sendo necessário adicionar a gem `faraday-multipart` individualmente no projeto para conseguir utilizar a Vindi

## Solução proposta
Definir a gem necessária como dependência

## Como testar
Ruby: 3.2.3
Rails: 7.1.3

Ao instalar a gem `vindi` deve ser possível utilizar o client:

Com a correção:
```rb
Vindi::Client.new.list_plans
=> []
```

Sem a correção:
```rb
Vindi::Client.new.list_plans
=> ...`lookup_middleware': :multipart is not registered on Faraday::Request (Faraday::Error)
```
